### PR TITLE
Compare entire vector since last Alignment against MinimumDeltaDistance

### DIFF
--- a/Assets/Mapbox/Unity/Ar/SimpleAutomaticSynchronizationContext.cs
+++ b/Assets/Mapbox/Unity/Ar/SimpleAutomaticSynchronizationContext.cs
@@ -26,8 +26,8 @@
 		Vector3 _currentArVector;
 		Vector3 _currentAbsoluteGpsVector;
 
-        Vector3 _previousArVector;
-        Vector3 _previousAbsoluteGpsVector;
+		Vector3 _previousArNode;
+		Vector3 _previousLocationPosition;
 
 		/// <summary>
 		/// The synchronization bias.
@@ -77,8 +77,8 @@
 			_count = _arNodes.Count;
 			if (_count > 1)
 			{
-				_currentArVector = arNode - _previousArVector;
-				_currentAbsoluteGpsVector = locationPosition - _previousAbsoluteGpsVector;
+				_currentArVector = arNode - _previousArNode;
+				_currentAbsoluteGpsVector = locationPosition - _previousLocationPosition;
 
 				// TODO: try to use ArTrustRange instead!
 				// This would mean no alignment is calculated until the threshold is met.
@@ -86,20 +86,21 @@
 				if (_currentArVector.magnitude < MinimumDeltaDistance || _currentAbsoluteGpsVector.magnitude < MinimumDeltaDistance)
 				{
 					Unity.Utilities.Console.Instance.Log("Minimum movement not yet met (arDelta: "+ _currentArVector.magnitude + ", gpsDelta: "+ _currentAbsoluteGpsVector.magnitude + ")", "red");
-                    return;
+					return;
 				}
 
 				ComputeAlignment();
 
-                _previousArVector = _currentArVector;
-                _previousAbsoluteGpsVector = _currentAbsoluteGpsVector;
-            }
-            else
-            {
-                //Initialize previous AR / GPS vectors
-                _previousArVector = arNode;
-                _previousAbsoluteGpsVector = locationPosition;
-            }
+				//Compute next alignment relative to current location.
+				_previousArNode = arNode;
+				_previousLocationPosition = locationPosition;
+			}
+			else
+			{
+				//Initialize previous AR / GPS vectors
+				_previousArNode = arNode;
+				_previousLocationPosition = locationPosition;
+			}
 		}
 
 		void ComputeAlignment()
@@ -124,8 +125,8 @@
 				bias = Mathf.Clamp01((.5f * (deltaDistance + ArTrustRange - accuracy)) / deltaDistance);
 			}
 
-            // Our new "origin" will be the difference offset between our last nodes (mapped into the same coordinate space).
-            var originOffset = _previousArVector - headingQuaternion * _previousAbsoluteGpsVector;
+			// Our new "origin" will be the difference offset between our last nodes (mapped into the same coordinate space).
+			var originOffset = _previousArNode - headingQuaternion * _previousLocationPosition;
 
 			// Add the weighted delta.
 			_position = (delta * bias) + originOffset;


### PR DESCRIPTION
Fixes #16.

I've let it continue to append to the _arNodes / _gpsPositions arrays even if the new readings have not moved more than MinimumDeltaDistance since this information might be useful in future, and instead keep track of a _previousArVector which is used to calculate _currentArVector as all movement since the last alignment.

I'm not entirely sure what this line is doing:

    var originOffset = _arNodes[_count - 2] - headingQuaternion * _gpsPositions[_count - 2];

It looks like it's finding the distance between the last recorded AR position and the last recorded GPS position (after rotating GPS position into AR space using the *new* headingQuaternion ). So originOffset would be the error in the *previous* alignment? I don't understand why this is useful?

I did test in the real world. It wasn't very accurate, but I think this was a pre-existing issue - it's hard to tell.