### PR TITLE
Deprecation note

### DIFF
--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -1,0 +1,5 @@
+# THIS REPOSITORY IS DEPREACTED!
+
+AR support been merged into the main repository https://github.com/mapbox/mapbox-unity-sdk/
+
+Please open issues or PRs there!

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,5 @@
+# THIS REPOSITORY IS DEPREACTED!
+
+AR support been merged into the main repository https://github.com/mapbox/mapbox-unity-sdk/
+
+Please open issues or PRs there!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 
+# THIS REPOSITORY IS DEPREACTED!
+
+AR support been merged into the main repository https://github.com/mapbox/mapbox-unity-sdk/
+
+Please open issues or PRs there!
+
+-----
+
 ![unity-repo-banner_preview](https://user-images.githubusercontent.com/4824060/34123144-9a78d322-e3fc-11e7-936f-d5e526ca8520.png)
 
 


### PR DESCRIPTION
This repository is being transferred into the main [mapbox-unity-sdk](https://github.com/mapbox/mapbox-unity-sdk):
PR: https://github.com/mapbox/mapbox-unity-sdk/pull/544

After above PR is merged merge this PR which includes:
- [x] deprecation note in the README
- [x] issue template with deprecation note
- [x] PR template with deprecation note